### PR TITLE
Datetime column sorting not working on users page

### DIFF
--- a/flexmeasures/ui/templates/crud/user.html
+++ b/flexmeasures/ui/templates/crud/user.html
@@ -70,7 +70,7 @@
                                 <td>
                                     Last login was
                                 </td>
-                                <td title="{{  user.last_login_at | localized_datetime }}">
+                                <td title="{{  user.last_login_at | localized_datetime }}" data-sort="{{ user.last_login_at }}">
                                     {{  user.last_login_at | naturalized_datetime }}
                                 </td>
                             </tr>
@@ -78,7 +78,7 @@
                                 <td>
                                     Last seen
                                 </td>
-                                <td title="{{  user.last_seen_at | localized_datetime }}">
+                                <td title="{{  user.last_seen_at | localized_datetime }}" data-sort="{{ user.last_seen_at }}">
                                     {{  user.last_seen_at | naturalized_datetime }}
                                 </td>
                             </tr>

--- a/flexmeasures/ui/templates/crud/users.html
+++ b/flexmeasures/ui/templates/crud/users.html
@@ -52,10 +52,10 @@
                                     <td>
                                         {{ user.timezone }}
                                     </td>
-                                    <td title="{{  user.last_login_at | localized_datetime }}">
+                                    <td title="{{  user.last_login_at | localized_datetime }}" data-sort="{{ user.last_login_at }}" >
                                         {{ user.last_login_at | naturalized_datetime}}
                                     </td>
-                                    <td title="{{  user.last_seen_at | localized_datetime }}">
+                                    <td title="{{  user.last_seen_at | localized_datetime }}" data-sort="{{ user.last_seen_at }}">
                                         {{ user.last_seen_at | naturalized_datetime}}
                                     </td>
                                     <td>


### PR DESCRIPTION
sort users by datetime for last-seen or last-login